### PR TITLE
Provide basic support for all Metric Types.

### DIFF
--- a/gnmi/gnmi.go
+++ b/gnmi/gnmi.go
@@ -22,7 +22,10 @@ import (
 	"time"
 
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	ompb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/openconfig/magna/lwotgtelem"
 	"github.com/openconfig/magna/lwotgtelem/gnmit"
 	"go.opentelemetry.io/collector/component"
@@ -104,6 +107,82 @@ func (g *GNMI) storeMetric(ctx context.Context, md pmetric.Metrics) error {
 	return nil
 }
 
+func marshalHistogramDataPoint(p *pmetric.HistogramDataPoint) (*anypb.Any, error) {
+	hp := &ompb.HistogramDataPoint{
+		Count:          p.Count(),
+		BucketCounts:   p.BucketCounts().AsRaw(),
+		ExplicitBounds: p.ExplicitBounds().AsRaw(),
+	}
+
+	if p.HasSum() {
+		hp.Sum = proto.Float64(p.Sum())
+	}
+	if p.HasMin() {
+		hp.Min = proto.Float64(p.Min())
+	}
+	if p.HasMax() {
+		hp.Max = proto.Float64(p.Max())
+	}
+	any, err := anypb.New(hp)
+	if err != nil {
+		return nil, err
+	}
+	return any, nil
+}
+
+func marshalExponentialHistogramDataPoint(p *pmetric.ExponentialHistogramDataPoint) (*anypb.Any, error) {
+	hp := &ompb.ExponentialHistogramDataPoint{
+		Count: p.Count(),
+		Scale: p.Scale(),
+		Positive: &ompb.ExponentialHistogramDataPoint_Buckets{
+			BucketCounts: p.Positive().BucketCounts().AsRaw(),
+			Offset:       p.Positive().Offset(),
+		},
+		Negative: &ompb.ExponentialHistogramDataPoint_Buckets{
+			BucketCounts: p.Negative().BucketCounts().AsRaw(),
+			Offset:       p.Negative().Offset(),
+		},
+		ZeroThreshold: p.ZeroThreshold(),
+		ZeroCount:     p.ZeroCount(),
+	}
+
+	if p.HasSum() {
+		hp.Sum = proto.Float64(p.Sum())
+	}
+	if p.HasMin() {
+		hp.Min = proto.Float64(p.Min())
+	}
+	if p.HasMax() {
+		hp.Max = proto.Float64(p.Max())
+	}
+	any, err := anypb.New(hp)
+	if err != nil {
+		return nil, err
+	}
+	return any, nil
+}
+
+func marshalSummaryDataPoint(p *pmetric.SummaryDataPoint) (*anypb.Any, error) {
+	qval := make([]*ompb.SummaryDataPoint_ValueAtQuantile, 0, p.QuantileValues().Len())
+	for i := 0; i < p.QuantileValues().Len(); i++ {
+		qval = append(qval, &ompb.SummaryDataPoint_ValueAtQuantile{
+			Quantile: p.QuantileValues().At(i).Quantile(),
+			Value:    p.QuantileValues().At(i).Value(),
+		})
+	}
+
+	sp := &ompb.SummaryDataPoint{
+		Count:          p.Count(),
+		QuantileValues: qval,
+	}
+
+	any, err := anypb.New(sp)
+	if err != nil {
+		return nil, err
+	}
+	return any, nil
+}
+
 // handleMetrics iterates over all received metrics and converts them into a
 // gNMI update. This set of updates are then packed into a gNMI notfication
 // and sent to the telemetry server.
@@ -112,28 +191,147 @@ func (g *GNMI) handleMetrics(_ gnmit.Queue, updateFn gnmit.UpdateFn, target stri
 	go func() {
 		for ms := range g.metricCh {
 			var updates []*gpb.Update
+
+			// Iterate over all resources (e.g., app).
 			rms := ms.ResourceMetrics()
 			for i := 0; i < rms.Len(); i++ {
 				rm := rms.At(i)
+
+				// Iterate over all instrument scopes within the resource (e.g., module within an app).
 				ilms := rm.ScopeMetrics()
 				for j := 0; j < ilms.Len(); j++ {
 					ilm := ilms.At(j)
+
+					// Iterate over all metrics for the instrument scope.
 					ms := ilm.Metrics()
 					for k := 0; k < ms.Len(); k++ {
 						m := ms.At(k)
+
+						// Handle each metric type.
 						switch m.Type() {
+						case pmetric.MetricTypeEmpty:
+							g.logger.Error("empty metric type", zap.String("name", m.Name()))
+							continue
+						case pmetric.MetricTypeGauge:
+							gaugeMetrics := m.Gauge().DataPoints()
+							for l := 0; l < gaugeMetrics.Len(); l++ {
+								gaugeMetric := gaugeMetrics.At(l)
+
+								// Data can be integers or doubles.
+								var val *gpb.TypedValue
+								switch gaugeMetric.ValueType() {
+								case pmetric.NumberDataPointValueTypeInt:
+									val = &gpb.TypedValue{
+										Value: &gpb.TypedValue_IntVal{
+											IntVal: gaugeMetric.IntValue(),
+										},
+									}
+								case pmetric.NumberDataPointValueTypeDouble:
+									val = &gpb.TypedValue{
+										Value: &gpb.TypedValue_DoubleVal{
+											DoubleVal: gaugeMetric.DoubleValue(),
+										},
+									}
+								case pmetric.NumberDataPointValueTypeEmpty:
+									continue
+								}
+								updates = append(updates, &gpb.Update{
+									Path: &gpb.Path{
+										Elem:   g.toPathElems(m.Name()),
+										Target: g.cfg.TargetName,
+									},
+									Val: val,
+								})
+							}
 						case pmetric.MetricTypeSum:
 							sumMetrics := m.Sum().DataPoints()
 							for l := 0; l < sumMetrics.Len(); l++ {
 								sumMetric := sumMetrics.At(l)
+								// Data can be integers or doubles.
+								var val *gpb.TypedValue
+								switch sumMetric.ValueType() {
+								case pmetric.NumberDataPointValueTypeInt:
+									val = &gpb.TypedValue{
+										Value: &gpb.TypedValue_IntVal{
+											IntVal: sumMetric.IntValue(),
+										},
+									}
+								case pmetric.NumberDataPointValueTypeDouble:
+									val = &gpb.TypedValue{
+										Value: &gpb.TypedValue_DoubleVal{
+											DoubleVal: sumMetric.DoubleValue(),
+										},
+									}
+								case pmetric.NumberDataPointValueTypeEmpty:
+									continue
+								}
+								updates = append(updates, &gpb.Update{
+									Path: &gpb.Path{
+										Elem:   g.toPathElems(m.Name()),
+										Target: g.cfg.TargetName,
+									},
+									Val: val,
+								})
+							}
+						case pmetric.MetricTypeHistogram:
+							histMetrics := m.Histogram().DataPoints()
+							for l := 0; l < histMetrics.Len(); l++ {
+								histMetric := histMetrics.At(l)
+								any, err := marshalHistogramDataPoint(&histMetric)
+								if err != nil {
+									g.logger.Error("failed to marshal histogram metric", zap.Error(err))
+									continue
+								}
 								updates = append(updates, &gpb.Update{
 									Path: &gpb.Path{
 										Elem:   g.toPathElems(m.Name()),
 										Target: g.cfg.TargetName,
 									},
 									Val: &gpb.TypedValue{
-										Value: &gpb.TypedValue_IntVal{
-											IntVal: sumMetric.IntValue(),
+										Value: &gpb.TypedValue_AnyVal{
+											AnyVal: any,
+										},
+									},
+								})
+							}
+						case pmetric.MetricTypeExponentialHistogram:
+							histMetrics := m.ExponentialHistogram().DataPoints()
+							for l := 0; l < histMetrics.Len(); l++ {
+								histMetric := histMetrics.At(l)
+								any, err := marshalExponentialHistogramDataPoint(&histMetric)
+								if err != nil {
+									g.logger.Error("failed to marshal exponential histogram metric", zap.Error(err))
+									continue
+								}
+								updates = append(updates, &gpb.Update{
+									Path: &gpb.Path{
+										Elem:   g.toPathElems(m.Name()),
+										Target: g.cfg.TargetName,
+									},
+									Val: &gpb.TypedValue{
+										Value: &gpb.TypedValue_AnyVal{
+											AnyVal: any,
+										},
+									},
+								})
+							}
+						case pmetric.MetricTypeSummary:
+							summaryMetrics := m.Summary().DataPoints()
+							for l := 0; l < summaryMetrics.Len(); l++ {
+								summaryMetric := summaryMetrics.At(l)
+								any, err := marshalSummaryDataPoint(&summaryMetric)
+								if err != nil {
+									g.logger.Error("failed to marshal summary metric", zap.Error(err))
+									continue
+								}
+								updates = append(updates, &gpb.Update{
+									Path: &gpb.Path{
+										Elem:   g.toPathElems(m.Name()),
+										Target: g.cfg.TargetName,
+									},
+									Val: &gpb.TypedValue{
+										Value: &gpb.TypedValue_AnyVal{
+											AnyVal: any,
 										},
 									},
 								})


### PR DESCRIPTION
This PR extends clio with basic support for all Metric Types and moves Notifications to a per-value basis. In particular, it entails the following:

- Added support for the Gauge Metric type and tests for adding integer and double values.
- Added support for the Histogram Metric type and a test case for it.
- Added support for the Exponential Histogram Metric type and a test case for it.
- Added support for the (Legacy) Summary Metric type and a test case for it.
- Extended the Sum Metric Type with support for double values and adjusted the test for it.
- Notifications are now sent per Metric value rather than per metric.

Caveats:
- The Histogram, ExponentialHistogram, and Summary Metric types are rather complex and hence can only be represented in a GNMI update via [any of the json value types or the any_val protobuf value type](https://github.com/openconfig/gnmi/blob/master/proto/gnmi/gnmi.proto#L126). This PR decided to go with the latter and re-uses Opentelemetry's proto definitions to populate the protobuf.

