### PR TITLE
rework telemetry handling

### DIFF
--- a/gnmi/gnmi.go
+++ b/gnmi/gnmi.go
@@ -16,6 +16,7 @@ package gnmi
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 
@@ -35,6 +36,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// GNMI is a gNMI exporter.
 type GNMI struct {
 	cfg *Config
 
@@ -46,6 +48,7 @@ type GNMI struct {
 	logger *zap.Logger
 }
 
+// NewGNMIExporter creates a new gNMI exporter.
 func NewGNMIExporter(logger *zap.Logger, cfg *Config) (*GNMI, error) {
 	telemSrv, err := lwotgtelem.New(context.Background(), cfg.TargetName)
 	if err != nil {
@@ -74,6 +77,7 @@ func NewGNMIExporter(logger *zap.Logger, cfg *Config) (*GNMI, error) {
 	}, nil
 }
 
+// Start starts the gNMI exporter.
 func (g *GNMI) Start(_ context.Context, _ component.Host) error {
 	g.logger.Info("starting gNMI exporter", zap.String("addr", g.cfg.Addr),
 		zap.String("target", g.cfg.TargetName), zap.String("origin", g.cfg.Origin),
@@ -90,6 +94,7 @@ func (g *GNMI) Start(_ context.Context, _ component.Host) error {
 	return nil
 }
 
+// Stop stops the gNMI exporter.
 func (g *GNMI) Stop(_ context.Context) error {
 	close(g.metricCh)
 	g.srv.GracefulStop()
@@ -222,14 +227,34 @@ func typedValueFromNumericMetric(p simpleNumberDataPoint) *gpb.TypedValue {
 	}
 }
 
+// attrMap is convenience definition for a map of attribute names to values for use in gNMI
+// notifications.
+type attrMap map[string]string
+
+// convO2GMap converts an OpenTelemetry map to a gNMI map.
+func convO2GMap(attrs pcommon.Map) attrMap {
+	if attrs.Len() == 0 {
+		return nil
+	}
+
+	gMap := make(attrMap)
+	attrs.Range(func(k string, v pcommon.Value) bool {
+		gMap[k] = v.AsString()
+		return true
+	})
+	return gMap
+}
+
 // typedValuesFromMetric returns a list of typed values based on a metric's values.
-func (g *GNMI) typedValuesAndTimesFromMetric(m pmetric.Metric) ([]*gpb.TypedValue, []pcommon.Timestamp) {
+func (g *GNMI) typedValuesAndTimesFromMetric(m pmetric.Metric) ([]*gpb.TypedValue, []pcommon.Timestamp, []attrMap) {
 	var tvals []*gpb.TypedValue
 	var tstamps []pcommon.Timestamp
+	var attrs []attrMap
+
 	switch m.Type() {
 	case pmetric.MetricTypeEmpty:
 		g.logger.Error("empty metric type", zap.String("name", m.Name()))
-		return nil, nil
+		return nil, nil, nil
 	case pmetric.MetricTypeGauge:
 		gaugeMetrics := m.Gauge().DataPoints()
 		for l := 0; l < gaugeMetrics.Len(); l++ {
@@ -241,6 +266,7 @@ func (g *GNMI) typedValuesAndTimesFromMetric(m pmetric.Metric) ([]*gpb.TypedValu
 			}
 			tvals = append(tvals, val)
 			tstamps = append(tstamps, gaugeMetric.Timestamp())
+			attrs = append(attrs, convO2GMap(gaugeMetric.Attributes()))
 		}
 	case pmetric.MetricTypeSum:
 		sumMetrics := m.Sum().DataPoints()
@@ -253,6 +279,7 @@ func (g *GNMI) typedValuesAndTimesFromMetric(m pmetric.Metric) ([]*gpb.TypedValu
 			}
 			tvals = append(tvals, val)
 			tstamps = append(tstamps, sumMetric.Timestamp())
+			attrs = append(attrs, convO2GMap(sumMetric.Attributes()))
 		}
 	case pmetric.MetricTypeHistogram:
 		histMetrics := m.Histogram().DataPoints()
@@ -265,6 +292,7 @@ func (g *GNMI) typedValuesAndTimesFromMetric(m pmetric.Metric) ([]*gpb.TypedValu
 			}
 			tvals = append(tvals, val)
 			tstamps = append(tstamps, histMetric.Timestamp())
+			attrs = append(attrs, convO2GMap(histMetric.Attributes()))
 		}
 	case pmetric.MetricTypeExponentialHistogram:
 		histMetrics := m.ExponentialHistogram().DataPoints()
@@ -277,6 +305,7 @@ func (g *GNMI) typedValuesAndTimesFromMetric(m pmetric.Metric) ([]*gpb.TypedValu
 			}
 			tvals = append(tvals, val)
 			tstamps = append(tstamps, histMetric.Timestamp())
+			attrs = append(attrs, convO2GMap(histMetric.Attributes()))
 		}
 	case pmetric.MetricTypeSummary:
 		sumMetrics := m.Summary().DataPoints()
@@ -289,22 +318,29 @@ func (g *GNMI) typedValuesAndTimesFromMetric(m pmetric.Metric) ([]*gpb.TypedValu
 			}
 			tvals = append(tvals, val)
 			tstamps = append(tstamps, sumMetric.Timestamp())
+			attrs = append(attrs, convO2GMap(sumMetric.Attributes()))
 		}
 	default:
 		g.logger.Error("unsupported metric type", zap.String("name", m.Name()), zap.String("type", m.Type().String()))
 	}
-	return tvals, tstamps
+	return tvals, tstamps, attrs
 }
 
 // notificationsFromMetric returns a list of gNMI notifications based on a metric.
-func (g *GNMI) notificationsFromMetric(p pmetric.Metric) []*gpb.Notification {
+func (g *GNMI) notificationsFromMetric(p pmetric.Metric, container string) []*gpb.Notification {
 	var notis []*gpb.Notification
-	values, timestamps := g.typedValuesAndTimesFromMetric(p)
+	values, timestamps, attrs := g.typedValuesAndTimesFromMetric(p)
 	if len(values) == 0 {
 		return nil
 	}
 
 	for i, val := range values {
+		// Some leaves are dependant on the attributes of the metric.
+		elems := g.toPathElems(p.Name())
+		if attrs[i] != nil {
+			elems[len(elems)-1].Key = attrs[i]
+		}
+
 		notis = append(notis, &gpb.Notification{
 			Timestamp: timestamps[i].AsTime().Unix(),
 			Prefix: &gpb.Path{
@@ -312,7 +348,7 @@ func (g *GNMI) notificationsFromMetric(p pmetric.Metric) []*gpb.Notification {
 				Target: g.cfg.TargetName,
 				Elem: []*gpb.PathElem{
 					{
-						Name: g.cfg.TargetName,
+						Name: container,
 					},
 				},
 			},
@@ -321,7 +357,7 @@ func (g *GNMI) notificationsFromMetric(p pmetric.Metric) []*gpb.Notification {
 					Path: &gpb.Path{
 						Target: g.cfg.TargetName,
 						Origin: g.cfg.Origin,
-						Elem:   g.toPathElems(p.Name()),
+						Elem:   elems,
 					},
 					Val: val,
 				},
@@ -344,6 +380,16 @@ func (g *GNMI) handleMetrics(_ gnmit.Queue, updateFn gnmit.UpdateFn, target stri
 			for i := 0; i < rms.Len(); i++ {
 				rm := rms.At(i)
 
+				// Extract container name from resource, default to "unknown-container".
+				cname := "unknown-container"
+				cNameVal, ok := rm.Resource().Attributes().Get("container.name")
+				if ok {
+					if cNameVal.Type() == pcommon.ValueTypeStr {
+						cname = cNameVal.Str()
+					}
+					g.logger.Error("resource has non-string container name", zap.String("resource", fmt.Sprintf("%+v", rm.Resource().Attributes().AsRaw())))
+				}
+
 				// Iterate over all instrument scopes within the resource (e.g., module within an app).
 				ilms := rm.ScopeMetrics()
 				for j := 0; j < ilms.Len(); j++ {
@@ -353,7 +399,7 @@ func (g *GNMI) handleMetrics(_ gnmit.Queue, updateFn gnmit.UpdateFn, target stri
 					ms := ilm.Metrics()
 					for k := 0; k < ms.Len(); k++ {
 						m := ms.At(k)
-						notis = append(notis, g.notificationsFromMetric(m)...)
+						notis = append(notis, g.notificationsFromMetric(m, cname)...)
 					}
 				}
 			}

--- a/gnmi/gnmi_test.go
+++ b/gnmi/gnmi_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      httinMetric://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,9 +20,30 @@ import (
 	"testing"
 	"time"
 
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	ompb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	anypb "google.golang.org/protobuf/types/known/anypb"
+)
+
+var (
+	metricStartTimestamp = pcommon.NewTimestampFromTime(time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC))
+	metricTimestamp      = pcommon.NewTimestampFromTime(time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC))
+)
+
+const (
+	TestSumIntMetricName               = "sum/int_and_double"
+	TestHistogramMetricName            = "histogram/double"
+	TestExponentialHistogramMetricName = "exponential-histogram/double"
+	TestGaugeMetricName                = "gauge/int_and_double"
+	TestSummaryMetricName              = "summary/double"
 )
 
 func TestHandleMetrics(t *testing.T) {
@@ -32,16 +53,19 @@ func TestHandleMetrics(t *testing.T) {
 		InMetricType pmetric.MetricType
 		inTarget     string
 		inOrigin     string
+		inResAttrs   map[string]string
 		wantCnt      int
 	}{
 		{
 			name:         "gauge-10",
+			inResAttrs:   map[string]string{"container.name": "test-container"},
 			inCnt:        10,
 			InMetricType: pmetric.MetricTypeGauge,
 			wantCnt:      20,
 		},
 		{
 			name:         "gauge-10-with-target",
+			inResAttrs:   map[string]string{"container.name": "test-container"},
 			inCnt:        10,
 			InMetricType: pmetric.MetricTypeGauge,
 			inTarget:     "moo-deng",
@@ -49,6 +73,7 @@ func TestHandleMetrics(t *testing.T) {
 		},
 		{
 			name:         "gauge-10-with-origin",
+			inResAttrs:   map[string]string{"container.name": "test-container"},
 			inCnt:        10,
 			InMetricType: pmetric.MetricTypeGauge,
 			inOrigin:     "capybara",
@@ -56,6 +81,7 @@ func TestHandleMetrics(t *testing.T) {
 		},
 		{
 			name:         "gauge-10-with-target-and-origin",
+			inResAttrs:   map[string]string{"container.name": "test-container"},
 			inCnt:        10,
 			InMetricType: pmetric.MetricTypeGauge,
 			inTarget:     "seals-on-ice-floe",
@@ -64,24 +90,28 @@ func TestHandleMetrics(t *testing.T) {
 		},
 		{
 			name:         "sum-10",
+			inResAttrs:   map[string]string{"container.name": "test-container"},
 			inCnt:        10,
 			InMetricType: pmetric.MetricTypeSum,
 			wantCnt:      20,
 		},
 		{
 			name:         "histogram-10",
+			inResAttrs:   map[string]string{"container.name": "test-container"},
 			inCnt:        10,
 			InMetricType: pmetric.MetricTypeHistogram,
 			wantCnt:      20,
 		},
 		{
 			name:         "exponential-histogram-10",
+			inResAttrs:   map[string]string{"container.name": "test-container"},
 			inCnt:        10,
 			InMetricType: pmetric.MetricTypeExponentialHistogram,
 			wantCnt:      20,
 		},
 		{
 			name:         "summary-10",
+			inResAttrs:   map[string]string{"container.name": "test-container"},
 			inCnt:        10,
 			InMetricType: pmetric.MetricTypeSummary,
 			wantCnt:      20,
@@ -90,6 +120,7 @@ func TestHandleMetrics(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := &GNMI{
+				logger: zap.NewExample(),
 				cfg: &Config{
 					TargetName: tc.inTarget,
 					Sep:        "/",
@@ -107,7 +138,7 @@ func TestHandleMetrics(t *testing.T) {
 				return nil
 			}
 
-			td := GenerateMetrics(tc.inCnt, tc.InMetricType)
+			td := GenerateMetrics(tc.inCnt, tc.InMetricType, tc.inResAttrs)
 			g.handleMetrics(nil, updateFn, "", nil)
 			if err := g.storeMetric(context.Background(), td); err != nil {
 				t.Errorf("storeMetric returned error: %v", err)
@@ -132,21 +163,8 @@ func TestHandleMetrics(t *testing.T) {
 	}
 }
 
-var (
-	metricStartTimestamp = pcommon.NewTimestampFromTime(time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC))
-	metricTimestamp      = pcommon.NewTimestampFromTime(time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC))
-)
-
-const (
-	TestSumIntMetricName               = "sum/int_and_double"
-	TestHistogramMetricName            = "histogram/double"
-	TestExponentialHistogramMetricName = "exponential-histogram/double"
-	TestGaugeMetricName                = "gauge/int_and_double"
-	TestSummaryMetricName              = "summary/double"
-)
-
-func GenerateMetrics(count int, ty pmetric.MetricType) pmetric.Metrics {
-	md := generateMetricsOneEmptyInstrumentationScope()
+func GenerateMetrics(count int, ty pmetric.MetricType, resAttrs map[string]string) pmetric.Metrics {
+	md := generateMetricsOneEmptyInstrumentationScope(resAttrs)
 	ms := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	ms.EnsureCapacity(count)
 
@@ -171,9 +189,12 @@ func initResource(r pcommon.Resource) {
 	r.Attributes().PutStr("resource-attr", "resource-attr-val-1")
 }
 
-func generateMetricsOneEmptyInstrumentationScope() pmetric.Metrics {
+func generateMetricsOneEmptyInstrumentationScope(resAttrs map[string]string) pmetric.Metrics {
 	md := pmetric.NewMetrics()
 	initResource(md.ResourceMetrics().AppendEmpty().Resource())
+	for k, v := range resAttrs {
+		md.ResourceMetrics().At(0).Resource().Attributes().PutStr(k, v)
+	}
 	md.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty()
 	return md
 }
@@ -316,5 +337,393 @@ func initMetric(m pmetric.Metric, name string, ty pmetric.MetricType) {
 		histo.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 	case pmetric.MetricTypeSummary:
 		m.SetEmptySummary()
+	}
+}
+
+func TestNotificationsFromMetric(t *testing.T) {
+	testPrefix := &gpb.Path{
+		Target: "test-target",
+		Origin: "test-origin",
+		Elem: []*gpb.PathElem{
+			{
+				Name: "test-target",
+			},
+		},
+	}
+
+	// anyWrapOrFatal is a convenience function to wrap a proto in an anypb.Any message.
+	anyWrapOrFatal := func(mgs proto.Message) *anypb.Any {
+		any, err := anypb.New(mgs)
+		if err != nil {
+			t.Fatalf("failed to wrap proto in anypb: %v", err)
+		}
+		return any
+	}
+
+	// The resource attributes are used to determine the container name/
+	resAttrs := map[string]string{"container.name": "test-container"}
+
+	// Special metric for which first update has attributes, and second update does not.
+	attredGaugeMetric := GenerateMetrics(10, pmetric.MetricTypeGauge, resAttrs).ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	attredGaugeMetric.Gauge().DataPoints().At(0).Attributes().PutStr("the-key", "the-value")
+
+	tests := []struct {
+		name     string
+		inMetric pmetric.Metric
+		inTarget string
+		want     []*gpb.Notification
+	}{
+		{
+			name:     "gauge-simple",
+			inMetric: GenerateMetrics(10, pmetric.MetricTypeGauge, resAttrs).ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0),
+			inTarget: "test-target",
+			want: []*gpb.Notification{
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "gauge"},
+									{Name: "int_and_double"},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_IntVal{
+									IntVal: 123,
+								},
+							},
+						},
+					},
+				},
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "gauge"},
+									{Name: "int_and_double"},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_DoubleVal{
+									DoubleVal: 456.0,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "gauge-with-attributes-in-first-update",
+			inMetric: attredGaugeMetric,
+			inTarget: "test-target",
+			want: []*gpb.Notification{
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "gauge"},
+									{
+										Name: "int_and_double",
+										Key:  map[string]string{"the-key": "the-value"},
+									},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_IntVal{
+									IntVal: 123,
+								},
+							},
+						},
+					},
+				},
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "gauge"},
+									{Name: "int_and_double"},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_DoubleVal{
+									DoubleVal: 456.0,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "sum-simple",
+			inMetric: GenerateMetrics(10, pmetric.MetricTypeSum, resAttrs).ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0),
+			inTarget: "test-target",
+			want: []*gpb.Notification{
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "sum"},
+									{Name: "int_and_double"},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_IntVal{
+									IntVal: 123,
+								},
+							},
+						},
+					},
+				},
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "sum"},
+									{Name: "int_and_double"},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_DoubleVal{
+									DoubleVal: 456.7,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "histogram-simple",
+			inMetric: GenerateMetrics(10, pmetric.MetricTypeHistogram, resAttrs).ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0),
+			inTarget: "test-target",
+			want: []*gpb.Notification{
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "histogram"},
+									{Name: "double"},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_AnyVal{
+									AnyVal: anyWrapOrFatal(&ompb.HistogramDataPoint{
+										Count:          110,
+										Min:            proto.Float64(1),
+										Max:            proto.Float64(91),
+										Sum:            proto.Float64(5555),
+										BucketCounts:   []uint64{0, 10, 100, 0},
+										ExplicitBounds: []float64{1.0, 10.0, 100.0},
+									}),
+								},
+							},
+						},
+					},
+				},
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "histogram"},
+									{Name: "double"},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_AnyVal{
+									AnyVal: anyWrapOrFatal(&ompb.HistogramDataPoint{
+										Count:          220,
+										Min:            proto.Float64(2),
+										Max:            proto.Float64(92),
+										Sum:            proto.Float64(7777),
+										BucketCounts:   []uint64{0, 20, 200, 0},
+										ExplicitBounds: []float64{1.0, 10.0, 100.0},
+									}),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "exponential-histogram-simple",
+			inMetric: GenerateMetrics(10, pmetric.MetricTypeExponentialHistogram, resAttrs).ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0),
+			inTarget: "test-target",
+			want: []*gpb.Notification{
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "exponential-histogram"},
+									{Name: "double"},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_AnyVal{
+									AnyVal: anyWrapOrFatal(&ompb.ExponentialHistogramDataPoint{
+										Count: 6,
+										Min:   proto.Float64(1),
+										Max:   proto.Float64(3),
+										Sum:   proto.Float64(7.1),
+										Negative: &ompb.ExponentialHistogramDataPoint_Buckets{
+											BucketCounts: []uint64{1, 2, 3, 0},
+											Offset:       0,
+										},
+										Positive: &ompb.ExponentialHistogramDataPoint_Buckets{},
+										Scale:    3,
+									}),
+								},
+							},
+						},
+					},
+				},
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "exponential-histogram"},
+									{Name: "double"},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_AnyVal{
+									AnyVal: anyWrapOrFatal(&ompb.ExponentialHistogramDataPoint{
+										Count: 7,
+										Min:   proto.Float64(2),
+										Max:   proto.Float64(3),
+										Sum:   proto.Float64(7.95),
+										Negative: &ompb.ExponentialHistogramDataPoint_Buckets{
+											BucketCounts: []uint64{3, 2, 2, 0},
+											Offset:       0,
+										},
+										Positive: &ompb.ExponentialHistogramDataPoint_Buckets{},
+										Scale:    3,
+									}),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "summary-simple",
+			inMetric: GenerateMetrics(10, pmetric.MetricTypeSummary, resAttrs).ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0),
+			inTarget: "test-target",
+			want: []*gpb.Notification{
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "summary"},
+									{Name: "double"},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_AnyVal{
+									AnyVal: anyWrapOrFatal(&ompb.SummaryDataPoint{
+										QuantileValues: []*ompb.SummaryDataPoint_ValueAtQuantile{
+											&ompb.SummaryDataPoint_ValueAtQuantile{
+												Quantile: 0.95,
+												Value:    9.5,
+											},
+										},
+									}),
+								},
+							},
+						},
+					},
+				},
+				&gpb.Notification{
+					Prefix: testPrefix,
+					Update: []*gpb.Update{
+						&gpb.Update{
+							Path: &gpb.Path{
+								Target: "test-target",
+								Origin: "test-origin",
+								Elem: []*gpb.PathElem{
+									{Name: "summary"},
+									{Name: "double"},
+								},
+							},
+							Val: &gpb.TypedValue{
+								Value: &gpb.TypedValue_AnyVal{
+									AnyVal: anyWrapOrFatal(&ompb.SummaryDataPoint{
+										QuantileValues: []*ompb.SummaryDataPoint_ValueAtQuantile{
+											&ompb.SummaryDataPoint_ValueAtQuantile{
+												Quantile: 0.9,
+												Value:    9.0,
+											},
+										},
+									}),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &GNMI{
+				logger: zap.NewExample(),
+				cfg: &Config{
+					TargetName: tc.inTarget,
+					Sep:        "/",
+					Origin:     "test-origin",
+				},
+			}
+			got := g.notificationsFromMetric(tc.inMetric, tc.inTarget)
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform(), cmpopts.EquateEmpty(), protocmp.IgnoreFields(&gpb.Notification{}, "timestamp")); diff != "" {
+				t.Errorf("notificationsFromMetric(%v, %q) returned an unexpected diff (-want +got): %v", tc.inMetric, tc.inTarget, diff)
+			}
+		})
 	}
 }

--- a/gnmi/gnmi_test.go
+++ b/gnmi/gnmi_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      httinMetric://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/gnmi/gnmi_test.go
+++ b/gnmi/gnmi_test.go
@@ -378,10 +378,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 			inMetric: GenerateMetrics(10, pmetric.MetricTypeGauge, resAttrs).ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0),
 			inTarget: "test-target",
 			want: []*gpb.Notification{
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -398,10 +398,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 						},
 					},
 				},
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -425,10 +425,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 			inMetric: attredGaugeMetric,
 			inTarget: "test-target",
 			want: []*gpb.Notification{
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -448,10 +448,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 						},
 					},
 				},
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -475,10 +475,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 			inMetric: GenerateMetrics(10, pmetric.MetricTypeSum, resAttrs).ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0),
 			inTarget: "test-target",
 			want: []*gpb.Notification{
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -495,10 +495,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 						},
 					},
 				},
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -522,10 +522,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 			inMetric: GenerateMetrics(10, pmetric.MetricTypeHistogram, resAttrs).ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0),
 			inTarget: "test-target",
 			want: []*gpb.Notification{
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -549,10 +549,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 						},
 					},
 				},
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -583,10 +583,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 			inMetric: GenerateMetrics(10, pmetric.MetricTypeExponentialHistogram, resAttrs).ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0),
 			inTarget: "test-target",
 			want: []*gpb.Notification{
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -614,10 +614,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 						},
 					},
 				},
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -652,10 +652,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 			inMetric: GenerateMetrics(10, pmetric.MetricTypeSummary, resAttrs).ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0),
 			inTarget: "test-target",
 			want: []*gpb.Notification{
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -668,7 +668,7 @@ func TestNotificationsFromMetric(t *testing.T) {
 								Value: &gpb.TypedValue_AnyVal{
 									AnyVal: anyWrapOrFatal(&ompb.SummaryDataPoint{
 										QuantileValues: []*ompb.SummaryDataPoint_ValueAtQuantile{
-											&ompb.SummaryDataPoint_ValueAtQuantile{
+											{
 												Quantile: 0.95,
 												Value:    9.5,
 											},
@@ -679,10 +679,10 @@ func TestNotificationsFromMetric(t *testing.T) {
 						},
 					},
 				},
-				&gpb.Notification{
+				{
 					Prefix: testPrefix,
 					Update: []*gpb.Update{
-						&gpb.Update{
+						{
 							Path: &gpb.Path{
 								Target: "test-target",
 								Origin: "test-origin",
@@ -695,7 +695,7 @@ func TestNotificationsFromMetric(t *testing.T) {
 								Value: &gpb.TypedValue_AnyVal{
 									AnyVal: anyWrapOrFatal(&ompb.SummaryDataPoint{
 										QuantileValues: []*ompb.SummaryDataPoint_ValueAtQuantile{
-											&ompb.SummaryDataPoint_ValueAtQuantile{
+											{
 												Quantile: 0.9,
 												Value:    9.0,
 											},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openconfig/clio
 go 1.22
 
 require (
-	github.com/google/go-cmp v0.6.0
+	github.com/google/go-cmp v0.7.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.102.0
 	github.com/openconfig/gnmi v0.11.0
 	github.com/openconfig/magna v0.0.0-20240326180454-518e16696c84

--- a/go.sum
+++ b/go.sum
@@ -1541,7 +1541,6 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/go.sum
+++ b/go.sum
@@ -1543,6 +1543,8 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-pkcs11 v0.2.0/go.mod h1:6eQoGcuNJpa7jnd5pMGdkSaQpNDYvPlXWMcjXXThLlY=
 github.com/google/go-pkcs11 v0.2.1-0.20230907215043-c6f79328ddf9/go.mod h1:6eQoGcuNJpa7jnd5pMGdkSaQpNDYvPlXWMcjXXThLlY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/integration/docker_stats_e2e/config/config.yaml
+++ b/integration/docker_stats_e2e/config/config.yaml
@@ -4,8 +4,6 @@ receivers:
     collection_interval: 2s
     initial_delay: 1s
     metrics:
-      # State
-      
       # Uptime
       container.uptime:
         enabled: true
@@ -151,6 +149,8 @@ processors:
 
 exporters:
   gnmi:
+    target_name: "poodle"
+    origin: "shiba"
 
 service:
   pipelines:

--- a/integration/oltp_e2e/config/config.yaml
+++ b/integration/oltp_e2e/config/config.yaml
@@ -10,6 +10,8 @@ processors:
 exporters:
   # NOTE: Prior to v0.86.0 use `logging` instead of `debug`.
   gnmi:
+    target_name: "poodle"
+    origin: "clio"
 
 service:
   pipelines:

--- a/integration/oltp_e2e/e2e_test.go
+++ b/integration/oltp_e2e/e2e_test.go
@@ -40,9 +40,10 @@ func subscribeRequestForTarget(t *testing.T, target string) *gpb.SubscribeReques
 					Target: target,
 					Elem: []*gpb.PathElem{
 						{
-							Name: "unknown-container",
+							Name: "test-container",
 						},
 					},
+					Origin: "clio",
 				},
 				Mode: gpb.SubscriptionList_STREAM,
 				Subscription: []*gpb.Subscription{
@@ -224,6 +225,10 @@ func generateMetrics(t *testing.T) pmetric.Metrics {
 	md.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty().Scope().SetName("resource-0-scope-0")
 	md.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty().Scope().SetName("resource-0-scope-1")
 	md.ResourceMetrics().At(1).ScopeMetrics().AppendEmpty().Scope().SetName("resource-1-scope-0")
+
+	// Ensure container names are set.
+	md.ResourceMetrics().At(0).Resource().Attributes().PutStr("container.name", "test-container")
+	md.ResourceMetrics().At(1).Resource().Attributes().PutStr("container.name", "test-container")
 
 	// Initialize metrics.
 	r0s0 := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()

--- a/integration/oltp_e2e/e2e_test.go
+++ b/integration/oltp_e2e/e2e_test.go
@@ -40,7 +40,7 @@ func subscribeRequestForTarget(t *testing.T, target string) *gpb.SubscribeReques
 					Target: target,
 					Elem: []*gpb.PathElem{
 						{
-							Name: target,
+							Name: "unknown-container",
 						},
 					},
 				},


### PR DESCRIPTION
Reworked telemetry to:
(1) prefix GNMI notification with the docker container they are received from
(2) properly convert OpenTelemetry attributes to gNMI.Notification attribute maps

+ minor fixes
+ adjustments for integration tests.