### PR TITLE
changing gnmi prefixes to OpenConfig-style keying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 # Run docker build from root of clio.
 RUN mkdir -p /go/src/github.com/clio/magna

--- a/gnmi/gnmi.go
+++ b/gnmi/gnmi.go
@@ -348,7 +348,11 @@ func (g *GNMI) notificationsFromMetric(p pmetric.Metric, container string) []*gp
 				Target: g.cfg.TargetName,
 				Elem: []*gpb.PathElem{
 					{
-						Name: container,
+						Name: "containers",
+					},
+					{
+						Name: "container",
+						Key:  map[string]string{"name": container},
 					},
 				},
 			},

--- a/integration/oltp_e2e/e2e_test.go
+++ b/integration/oltp_e2e/e2e_test.go
@@ -40,7 +40,11 @@ func subscribeRequestForTarget(t *testing.T, target string) *gpb.SubscribeReques
 					Target: target,
 					Elem: []*gpb.PathElem{
 						{
-							Name: "test-container",
+							Name: "containers",
+						},
+						{
+							Name: "container",
+							Key:  map[string]string{"name": "test-container"},
 						},
 					},
 					Origin: "clio",


### PR DESCRIPTION
This Cl:
- changes how clio sets the prefix of notifications
- changes the unit & integration tests accordingly
- changes the golang version of the dockerfile (previously broken)